### PR TITLE
feat: add page object model based test for adding and verifying todos in TodoMVC

### DIFF
--- a/pageObjects/todo.ts
+++ b/pageObjects/todo.ts
@@ -1,0 +1,23 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class TodoPage {
+  private readonly page: Page;
+  private readonly newTodoTextbox: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.newTodoTextbox = page.getByRole("textbox", {
+      name: "What needs to be done?",
+    });
+  }
+
+  async addTodo(todo: string) {
+    await this.newTodoTextbox.fill(todo);
+    await this.newTodoTextbox.press("Enter");
+  }
+
+  async getAllTodoTitles() {
+    const todoTitles = await this.page.getByTestId("todo-title").all();
+    return Promise.all(todoTitles.map((todoTitle) => todoTitle.textContent()));
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: "https://demo.playwright.dev",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/tests/todo.spec.ts
+++ b/tests/todo.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+import { TodoPage } from "../pageObjects/todo";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/todomvc");
+});
+
+test("should add multiple todos and verify their titles", async ({ page }) => {
+  const todoPage = new TodoPage(page);
+
+  const todos = ["todo1", "todo2"];
+  for (const todo of todos) {
+    await todoPage.addTodo(todo);
+  }
+
+  const allTodoTitles = await todoPage.getAllTodoTitles();
+  expect(allTodoTitles).toEqual(todos);
+});


### PR DESCRIPTION
- configure Playwright with baseURL for consistent test navigation
- create TodoPage class with methods to add and retrieve todos
- implement test to add multiple todos and verify their titles in order